### PR TITLE
Fix RDS scheduler variables comment

### DIFF
--- a/modules/rds_scheduler/variables.tf
+++ b/modules/rds_scheduler/variables.tf
@@ -1,4 +1,4 @@
-# This file contains the variable definitions for the EC2 Scheduler module.
+# This file contains the variable definitions for the RDS Scheduler module.
 
 # The "name" variable is used as a prefix for the resources' names.
 variable "name" {


### PR DESCRIPTION
## Summary
- update `variables.tf` header comment for RDS scheduler module

## Testing
- `terraform fmt -check -recursive`
- `terraform init -backend=false` *(fails: could not connect to registry)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_684056ad235c8333a8081d7000a69540