### PR TITLE
Add unit tests and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .vscode/
 .DS_Store
 .terraform/
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ No inputs.
 
 No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Running tests
+
+Install the development dependencies and run `pytest` from the repository root:
+
+```bash
+pip install pytest boto3 moto
+pytest
+```

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1,0 +1,59 @@
+import importlib.util
+import os
+from unittest.mock import MagicMock, patch
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+
+# Load modules dynamically while patching boto3 clients so that no AWS calls occur
+with patch("boto3.client", return_value=MagicMock()):
+    _ec2_spec = importlib.util.spec_from_file_location(
+        "ec2_main", os.path.join(ROOT, "modules", "ec2_scheduler", "main.py")
+    )
+    ec2_main = importlib.util.module_from_spec(_ec2_spec)
+    _ec2_spec.loader.exec_module(ec2_main)
+
+    _rds_spec = importlib.util.spec_from_file_location(
+        "rds_main", os.path.join(ROOT, "modules", "rds_scheduler", "main.py")
+    )
+    rds_main = importlib.util.module_from_spec(_rds_spec)
+    _rds_spec.loader.exec_module(rds_main)
+
+
+def test_get_list_of_servers_with_tag_stop():
+    mock_ec2 = MagicMock()
+    mock_ec2.describe_instances.return_value = {
+        "Reservations": [
+            {"Instances": [{"InstanceId": "i-1"}, {"InstanceId": "i-2"}]}
+        ]
+    }
+    with patch.object(ec2_main, "ec2", mock_ec2):
+        result = ec2_main.get_list_of_servers_with_tag("Env", "dev", "STOP")
+        assert result == ["i-1", "i-2"]
+        mock_ec2.describe_instances.assert_called_with(
+            Filters=[
+                {"Name": "tag:Env", "Values": ["dev"]},
+                {"Name": "instance-state-name", "Values": ["running"]},
+            ]
+        )
+
+
+def test_get_list_of_db_instances_with_tag_start():
+    mock_rds = MagicMock()
+    mock_rds.describe_db_instances.return_value = {
+        "DBInstances": [
+            {
+                "DBInstanceIdentifier": "db-1",
+                "DBInstanceStatus": "stopped",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:db:db-1",
+            }
+        ]
+    }
+    mock_rds.list_tags_for_resource.return_value = {
+        "TagList": [{"Key": "Env", "Value": "dev"}]
+    }
+    with patch.object(rds_main, "rds", mock_rds):
+        result = rds_main.get_list_of_db_instances_with_tag("Env", "dev", "START")
+        assert result == ["db-1"]
+        mock_rds.list_tags_for_resource.assert_called_with(
+            ResourceName="arn:aws:rds:us-east-1:123456789012:db:db-1"
+        )


### PR DESCRIPTION
## Summary
- add pytest-based tests for EC2 and RDS schedulers
- ignore Python cache and test artifacts
- document how to run the tests in the README

## Testing
- `pip install pytest boto3 moto`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684061d8853483338124c68308d1fd48