### PR TITLE
Create shared scheduler module

### DIFF
--- a/modules/ec2_scheduler/main.py
+++ b/modules/ec2_scheduler/main.py
@@ -1,83 +1,39 @@
-import boto3
-import os
+from modules.scheduler_common import BaseScheduler
+from modules.logger_config import get_logger
 
-EC2TAG_KEY   = os.getenv("EC2TAG_KEY")
-EC2TAG_VALUE = os.getenv("EC2TAG_VALUE")
-EC2_ACTION   = os.getenv("EC2_ACTION")
+logger = get_logger(__name__)
 
-ec2 = boto3.client('ec2')
+class EC2Scheduler(BaseScheduler):
+    def __init__(self):
+        super().__init__("ec2", "EC2TAG_KEY", "EC2TAG_VALUE", "EC2_ACTION")
 
-def get_list_of_servers_with_tag(EC2TAG_KEY, EC2TAG_VALUE, EC2_ACTION):
-    """
-    Retrieves a list of EC2 server IDs that have a specific tag and meet the specified instance state criteria.
+    def get_resource_ids(self):
+        instance_state_values = ["running"] if self.action == "STOP" else ["stopped"] if self.action == "START" else []
+        response = self.client.describe_instances(
+            Filters=[
+                {"Name": "tag:" + self.tag_key, "Values": [self.tag_value]},
+                {"Name": "instance-state-name", "Values": instance_state_values},
+            ]
+        )
+        server_ids = [server["InstanceId"] for reservation in response["Reservations"] for server in reservation["Instances"]]
+        self.logger.info(f"Servers to {self.action} in {self.region}: {server_ids}")
+        return server_ids
 
-    Args:
-        EC2TAG_KEY (str): The key of the tag to filter the EC2 instances.
-        EC2TAG_VALUE (str): The value of the tag to filter the EC2 instances.
-        EC2_ACTION (str): The action to perform on the EC2 instances. Valid values are "START" or "STOP".
+    def start_resources(self, ids):
+        self.client.start_instances(InstanceIds=ids)
 
-    Returns:
-        list: A list of EC2 server IDs that match the tag and instance state criteria.
-    """
-    instance_state_values = ["running"] if EC2_ACTION == "STOP" else ["stopped"] if EC2_ACTION == "START" else []
+    def stop_resources(self, ids):
+        self.client.stop_instances(InstanceIds=ids)
 
-    response = ec2.describe_instances(
-        Filters=[
-            {
-                'Name': "tag:" + EC2TAG_KEY,
-                'Values': [EC2TAG_VALUE]
-            },
-            {
-                'Name': "instance-state-name",
-                'Values': instance_state_values
-            }
-        ]
-    )
 
-    server_ids = [server['InstanceId'] for reservation in response['Reservations'] for server in reservation['Instances']]
-    return server_ids
+scheduler = EC2Scheduler()
+
+def get_list_of_servers_with_tag(tag_key, tag_value, action):
+    scheduler.tag_key = tag_key
+    scheduler.tag_value = tag_value
+    scheduler.action = action
+    return scheduler.get_resource_ids()
+
 
 def lambda_handler(event, context):
-    """
-    Lambda function handler that performs the specified action on EC2 instances with a specific tag.
-
-    Args:
-        event (dict): The event data passed to the Lambda function.
-        context (object): The runtime information of the Lambda function.
-
-    Returns:
-        dict: The response object containing the status code and body of the Lambda function execution.
-    """
-    try:
-        server_ids = get_list_of_servers_with_tag(EC2TAG_KEY, EC2TAG_VALUE, EC2_ACTION)
-        if not server_ids:
-            print(f"No Servers to {EC2_ACTION}")
-            return {
-                'statusCode': 200,
-                'body': f'No instances to {EC2_ACTION} with tag {EC2TAG_KEY}:{EC2TAG_VALUE}'
-            }
-
-        print(f"Servers to {EC2_ACTION}: {server_ids}")
-
-        if EC2_ACTION == "STOP":
-            ec2.stop_instances(InstanceIds=server_ids)
-        elif EC2_ACTION == "START":
-            ec2.start_instances(InstanceIds=server_ids)
-        else:
-            print("Invalid EC2_ACTION value. Please set EC2_ACTION to STOP or START.")
-            return {
-                'statusCode': 400,
-                'body': 'Invalid EC2_ACTION value. Please set EC2_ACTION to STOP or START.'
-            }
-
-    except Exception as error:
-        print(f"Error occurred! Error Message: {error}")
-        return {
-            'statusCode': 500,
-            'body': f'Error occurred! Error Message: {error}'
-        }
-
-    return {
-        'statusCode': 200,
-        'body': f'{EC2_ACTION} action performed on EC2 instances with tag {EC2TAG_KEY}:{EC2TAG_VALUE}'
-    }
+    return scheduler.lambda_handler(event, context)

--- a/modules/logger_config.py
+++ b/modules/logger_config.py
@@ -1,0 +1,14 @@
+import logging
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger configured with standard formatting."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger

--- a/modules/rds_scheduler/main.py
+++ b/modules/rds_scheduler/main.py
@@ -1,83 +1,46 @@
-import boto3
-import os
+from modules.scheduler_common import BaseScheduler
+from modules.logger_config import get_logger
 
-RDSTAG_KEY    = os.getenv("RDSTAG_KEY")
-RDSTAG_VALUE  = os.getenv("RDSTAG_VALUE")
-RDS_ACTION    = os.getenv("RDS_ACTION")
+logger = get_logger(__name__)
 
-rds = boto3.client('rds')
+class RDSScheduler(BaseScheduler):
+    def __init__(self):
+        super().__init__("rds", "RDSTAG_KEY", "RDSTAG_VALUE", "RDS_ACTION")
 
-def get_list_of_db_instances_with_tag(RDSTAG_KEY, RDSTAG_VALUE, RDS_ACTION):
-    """
-    Retrieves a list of RDS DB instances with a specific tag and matching
-    instance state. Tags are fetched for each instance using
-    ``list_tags_for_resource``.
-
-    Args:
-        RDSTAG_KEY (str): The key of the tag to match.
-        RDSTAG_VALUE (str): The value of the tag to match.
-        RDS_ACTION (str): The action to perform on the matched instances. Valid values are "START" or "STOP".
-
-    Returns:
-        list: A list of DB instance identifiers matching the specified tag and instance state.
-    """
-    db_instance_ids = []
-    instance_state_values = ["available"] if RDS_ACTION == "STOP" else ["stopped"] if RDS_ACTION == "START" else []
-
-    paginator = rds.get_paginator('describe_db_instances')
-    for page in paginator.paginate():
-        for instance in page['DBInstances']:
+    def get_resource_ids(self):
+        db_instance_ids = []
+        instance_state_values = ["available"] if self.action == "STOP" else ["stopped"] if self.action == "START" else []
+        response = self.client.describe_db_instances()
+        for instance in response.get('DBInstances', []):
             if instance['DBInstanceStatus'] in instance_state_values:
                 arn = instance['DBInstanceArn']
-                tags_response = rds.list_tags_for_resource(ResourceName=arn)
+                tags_response = self.client.list_tags_for_resource(ResourceName=arn)
                 for tag in tags_response.get('TagList', []):
-                    if tag['Key'] == RDSTAG_KEY and tag['Value'] == RDSTAG_VALUE:
+                    if tag['Key'] == self.tag_key and tag['Value'] == self.tag_value:
                         db_instance_ids.append(instance['DBInstanceIdentifier'])
+                        self.logger.info(
+                            f"Matched DB instance {instance['DBInstanceIdentifier']} ({arn}) in {self.region}"
+                        )
                         break
+        return db_instance_ids
+
+    def start_resources(self, ids):
+        for db_instance_id in ids:
+            self.client.start_db_instance(DBInstanceIdentifier=db_instance_id)
+
+    def stop_resources(self, ids):
+        for db_instance_id in ids:
+            self.client.stop_db_instance(DBInstanceIdentifier=db_instance_id)
 
 
-    return db_instance_ids
+scheduler = RDSScheduler()
+
+def get_list_of_db_instances_with_tag(tag_key, tag_value, action):
+    scheduler.tag_key = tag_key
+    scheduler.tag_value = tag_value
+    scheduler.action = action
+    return scheduler.get_resource_ids()
+
 
 def lambda_handler(event, context):
-    """
-    Lambda function handler that performs the specified action on RDS instances with a specific tag.
-
-    Args:
-        event (dict): The event data passed to the Lambda function.
-        context (object): The runtime information of the Lambda function.
-
-    Returns:
-        dict: The response object containing the status code and body message.
-    """
-    try:
-        db_instance_ids = get_list_of_db_instances_with_tag(RDSTAG_KEY, RDSTAG_VALUE, RDS_ACTION)
-        if not db_instance_ids:
-            print(f"DB instances to {RDS_ACTION}: {db_instance_ids}")
-            return {
-                'statusCode': 200,
-                'body': f'No instances to {RDS_ACTION} with tag {RDSTAG_KEY}:{RDSTAG_VALUE}'
-            }
-
-        for db_instance_id in db_instance_ids:
-            if RDS_ACTION == "STOP":
-                rds.stop_db_instance(DBInstanceIdentifier=db_instance_id)
-            elif RDS_ACTION == "START":
-                rds.start_db_instance(DBInstanceIdentifier=db_instance_id)
-            else:
-                print("Invalid RDS_ACTION value. Please set RDS_ACTION to STOP or START.")
-                return {
-                    'statusCode': 400,
-                    'body': 'Invalid RDS_ACTION value. Please set RDS_ACTION to STOP or START.'
-                }
-
-    except Exception as error:
-        print(f"Error occurred! Error Message: {error}")
-        return {
-            'statusCode': 500,
-            'body': f'Error occurred! Error Message: {error}'
-        }
-
-    return {
-        'statusCode': 200,
-        'body': f'{RDS_ACTION} action performed on RDS instances with tag {RDSTAG_KEY}:{RDSTAG_VALUE}'
-    }
+    return scheduler.lambda_handler(event, context)

--- a/modules/scheduler_common.py
+++ b/modules/scheduler_common.py
@@ -1,0 +1,66 @@
+import os
+import boto3
+from modules.logger_config import get_logger
+
+class BaseScheduler:
+    """Base scheduler implementing shared start/stop logic."""
+
+    def __init__(self, service_name: str, tag_key_var: str, tag_value_var: str, action_var: str):
+        self.client = boto3.client(service_name)
+        self.tag_key_var = tag_key_var
+        self.tag_value_var = tag_value_var
+        self.action_var = action_var
+        self.tag_key = os.getenv(tag_key_var)
+        self.tag_value = os.getenv(tag_value_var)
+        self.action = os.getenv(action_var)
+        self.region = self.client.meta.region_name
+        self.logger = get_logger(__name__)
+
+    def get_resource_ids(self):
+        """Return a list of resource identifiers to operate on."""
+        raise NotImplementedError
+
+    def start_resources(self, ids):
+        """Start resources identified by *ids*."""
+        raise NotImplementedError
+
+    def stop_resources(self, ids):
+        """Stop resources identified by *ids*."""
+        raise NotImplementedError
+
+    def lambda_handler(self, event, context):
+        """Common Lambda handler performing the desired action."""
+        try:
+            ids = self.get_resource_ids()
+            if not ids:
+                self.logger.info(f"No resources to {self.action} in {self.region}")
+                return {
+                    'statusCode': 200,
+                    'body': f'No instances to {self.action} with tag {self.tag_key}:{self.tag_value}'
+                }
+
+            if self.action == "STOP":
+                self.stop_resources(ids)
+                self.logger.info(f"Stopping {ids} in {self.region}")
+            elif self.action == "START":
+                self.start_resources(ids)
+                self.logger.info(f"Starting {ids} in {self.region}")
+            else:
+                self.logger.error(
+                    f"Invalid {self.action_var} value. Please set {self.action_var} to STOP or START."
+                )
+                return {
+                    'statusCode': 400,
+                    'body': f'Invalid {self.action_var} value. Please set {self.action_var} to STOP or START.'
+                }
+        except Exception as error:  # pragma: no cover - defensive
+            self.logger.exception(f"Error occurred in region {self.region}: {error}")
+            return {
+                'statusCode': 500,
+                'body': f'Error occurred! Error Message: {error}'
+            }
+
+        return {
+            'statusCode': 200,
+            'body': f'{self.action} action performed on resources with tag {self.tag_key}:{self.tag_value}'
+        }

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1,8 +1,10 @@
 import importlib.util
 import os
+import sys
 from unittest.mock import MagicMock, patch
 
 ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
 
 # Load modules dynamically while patching boto3 clients so that no AWS calls occur
 with patch("boto3.client", return_value=MagicMock()):
@@ -26,7 +28,7 @@ def test_get_list_of_servers_with_tag_stop():
             {"Instances": [{"InstanceId": "i-1"}, {"InstanceId": "i-2"}]}
         ]
     }
-    with patch.object(ec2_main, "ec2", mock_ec2):
+    with patch.object(ec2_main.scheduler, "client", mock_ec2):
         result = ec2_main.get_list_of_servers_with_tag("Env", "dev", "STOP")
         assert result == ["i-1", "i-2"]
         mock_ec2.describe_instances.assert_called_with(
@@ -51,7 +53,7 @@ def test_get_list_of_db_instances_with_tag_start():
     mock_rds.list_tags_for_resource.return_value = {
         "TagList": [{"Key": "Env", "Value": "dev"}]
     }
-    with patch.object(rds_main, "rds", mock_rds):
+    with patch.object(rds_main.scheduler, "client", mock_rds):
         result = rds_main.get_list_of_db_instances_with_tag("Env", "dev", "START")
         assert result == ["db-1"]
         mock_rds.list_tags_for_resource.assert_called_with(


### PR DESCRIPTION
## Summary
- implement `BaseScheduler` to share common logic
- refactor EC2 and RDS lambda code to use `BaseScheduler`
- update tests for the new scheduler objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406ac3fe5c8333a03a0245b1f06c1f