### PR TITLE
Fix terraform docs hook argument

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     - id: terraform_docs
       args:
         #- --hook-config=--path-to-file=../../README.md
-        - --hook-config=--add-to-exiting-file=true
+        - --hook-config=--add-to-existing-file=true
         - --hook-config=--create-file-if-not-exist=true
 
 - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Summary
- fix a typo in `.pre-commit-config.yaml`

## Testing
- `pre-commit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405571db408333b844358aed850acc