### PR TITLE
Add Terraform validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 
 ## Running tests
 
-Install the development dependencies and run `pytest` from the repository root:
+Install the development dependencies and run `pytest` from the repository root.
+Terraform must also be available in `PATH` so that the infrastructure code can
+be validated during the test run:
 
 ```bash
 pip install pytest boto3 moto

--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -1,0 +1,25 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TERRAFORM_DIRS = [
+    ROOT,
+    ROOT / "modules" / "ec2_scheduler",
+    ROOT / "modules" / "rds_scheduler",
+]
+
+@pytest.mark.parametrize("tf_dir", TERRAFORM_DIRS)
+def test_terraform_validate(tf_dir):
+    env = os.environ.copy()
+    env["TF_IN_AUTOMATION"] = "1"
+    init_cmd = ["terraform", f"-chdir={tf_dir}", "init", "-backend=false", "-input=false"]
+    try:
+        subprocess.run(init_cmd, check=True, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as exc:
+        pytest.skip(f"terraform init failed: {exc.stderr.decode().strip()}")
+    subprocess.run(["terraform", f"-chdir={tf_dir}", "validate", "-no-color"], check=True, env=env)
+


### PR DESCRIPTION
## Summary
- add python-based tests that run `terraform init` and `validate`
- mention terraform requirement in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684176fe5e408333bec500c409f6b528