### PR TITLE
Fix terraform test skip

### DIFF
--- a/tests/test_terraform.py
+++ b/tests/test_terraform.py
@@ -12,14 +12,36 @@ TERRAFORM_DIRS = [
     ROOT / "modules" / "rds_scheduler",
 ]
 
+
 @pytest.mark.parametrize("tf_dir", TERRAFORM_DIRS)
 def test_terraform_validate(tf_dir):
     env = os.environ.copy()
     env["TF_IN_AUTOMATION"] = "1"
-    init_cmd = ["terraform", f"-chdir={tf_dir}", "init", "-backend=false", "-input=false"]
+    init_cmd = [
+        "terraform",
+        f"-chdir={tf_dir}",
+        "init",
+        "-backend=false",
+        "-input=false",
+    ]
     try:
-        subprocess.run(init_cmd, check=True, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(
+            init_cmd,
+            check=True,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        pytest.skip("terraform executable not found; skipping test")
     except subprocess.CalledProcessError as exc:
         pytest.skip(f"terraform init failed: {exc.stderr.decode().strip()}")
-    subprocess.run(["terraform", f"-chdir={tf_dir}", "validate", "-no-color"], check=True, env=env)
 
+    try:
+        subprocess.run(
+            ["terraform", f"-chdir={tf_dir}", "validate", "-no-color"],
+            check=True,
+            env=env,
+        )
+    except FileNotFoundError:
+        pytest.skip("terraform executable not found; skipping test")


### PR DESCRIPTION
## Summary
- skip terraform validation tests when Terraform isn't installed

## Testing
- `flake8 tests/test_terraform.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841836ea134833389ecdcbaa53ac2f7